### PR TITLE
updated: Postifix SMTP Authentication. Grafana and Influxdb is configured to use local Postfix.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,11 +75,12 @@
 #	Set the grafana log level (e.g. debug)
 #
 # IOT_DASHBOARD_GRAFANA_SMTP_ENABLED
-#	Set to true to enable SMTP.
+#	Set to false to disable SMTP.
+# Defaults to true
 #
 # IOT_DASHBOARD_GRAFANA_SMTP_SKIP_VERIFY
-#	Set to true to disable SSL verification.
-#	Defaults to false.
+#	Set to false to enable SSL verification.
+#	Defaults to true.
 #
 # IOT_DASHBOARD_GRAFANA_INSTALL_PLUGINS
 #	A list of grafana plugins to install. Use (comma and space) ", " to delimit plugins.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,7 +219,7 @@ services:
         distrib_id: "${IOT_DASHBOARD_OS_DISTRIB_ID:-ubuntu}"
         distrib_codename: "${IOT_DASHBOARD_OS_DISTRIB_CODENAME:-xenial}"
         hostname: "${IOT_DASHBOARD_INFLUXDB_MAIL_HOST_NAME:-.}"
-        relay_ip: "${IOT_DASHBOARD_MAIL_RELAY_IP:-.}"
+        relay_ip: "postfix:25"
         domain: "${IOT_DASHBOARD_MAIL_DOMAIN:-.}"
     hostname: "${IOT_DASHBOARD_INFLUXDB_MAIL_HOST_NAME:-.}"
     expose:
@@ -251,8 +251,8 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: "${IOT_DASHBOARD_GRAFANA_ADMIN_PASSWORD:-!notset}"
       GF_SERVER_DOMAIN: "${IOT_DASHBOARD_NGINX_FQDN}"
       GF_SERVER_ROOT_URL: "https://%(domain)s/grafana/"
-      GF_SMTP_ENABLED: "${IOT_DASHBOARD_GRAFANA_SMTP_ENABLED:-false}"
-      GF_SMTP_SKIP_VERIFY: "${IOT_DASHBOARD_GRAFANA_SMTP_SKIP_VERIFY:-false}"
+      GF_SMTP_ENABLED: "${IOT_DASHBOARD_GRAFANA_SMTP_ENABLED:-true}"
+      GF_SMTP_SKIP_VERIFY: "${IOT_DASHBOARD_GRAFANA_SMTP_SKIP_VERIFY:-true}"
       GF_SMTP_HOST: "postfix:25"
       GF_SMTP_FROM_ADDRESS: "${IOT_DASHBOARD_GRAFANA_SMTP_FROM_ADDRESS:-grafana@localhost}"
       GF_SMTP_FROM_NAME: "${IOT_DASHBOARD_GRAFANA_PROJECT_NAME:-Default} grafana admin"
@@ -274,6 +274,8 @@ services:
         hostname: "${IOT_DASHBOARD_MAIL_HOST_NAME:-.}"
         relay_ip: "${IOT_DASHBOARD_MAIL_RELAY_IP:-.}"
         domain: "${IOT_DASHBOARD_MAIL_DOMAIN:-.}"
+        smtp_login: "${IOT_DASHBOARD_MAIL_SMTP_LOGIN:-.}"
+        smtp_password: "${IOT_DASHBOARD_MAIL_SMTP_PASSWORD:-.}"
     expose:
       - "25"
     hostname: "${IOT_DASHBOARD_MAIL_HOST_NAME:-.}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,13 @@
 # IOT_DASHBOARD_MAIL_RELAY_IP
 #       the mail relay machine, assuming that the real mailer is upstream from us.
 #
+# IOT_DASHBOARD_MAIL_SMTP_LOGIN
+#       the mail relay login: name@example.com -- it will come from your upstream
+#       provider.
+#
+# IOT_DASHBOARD_MAIL_SMTP_PASSWORD
+#       the mail relay password
+#
 # IOT_DASHBOARD_PORT_HTTP
 #	The port to listen to for HTTP. Primarily for test purposes. Defaults to
 #	80.

--- a/influxdb/Dockerfile
+++ b/influxdb/Dockerfile
@@ -30,19 +30,12 @@ ARG domain
 
 # Install Postfix
 run echo "postfix postfix/mailname string $host_name" | debconf-set-selections
-run echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-selections
+run echo "postfix postfix/main_mailer_type select Satellite system" | debconf-set-selections
 run apt-get update && apt-get install -y postfix
 run postconf -e relayhost=$relay_ip
-run postconf -e myhostname=$hostname
-run postconf -e mydomain=$domain
-run postconf -e masquerade_domains=$domain
-run postconf -e mydestination="\$myhostname, $hostname, localhost, localhost.localdomain, localhost"
-run postconf -e mynetworks="127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 172.0.0.0/8"
-run postconf -e smtpd_use_tls=no
-run echo $domain > /etc/mailname
 
 # This will replace local mail addresses by valid Internet addresses when mail leaves the machine via SMTP.
-run echo "root@${domain} influxdbbackup@${domain}" > /etc/postfix/generic
+run echo "root@${hostname} influxdbbackup@${domain}" > /etc/postfix/generic
 run postconf -e smtp_generic_maps=hash:/etc/postfix/generic
 run postmap /etc/postfix/generic
 

--- a/postfix/Dockerfile
+++ b/postfix/Dockerfile
@@ -14,22 +14,34 @@ RUN apt-get update && apt-get install -y \
 ARG hostname
 ARG relay_ip
 ARG domain
+ARG smtp_login
+ARG smtp_password
 
 # Install Postfix
-run echo "postfix postfix/mailname string $host_name" | debconf-set-selections
-run echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-selections
-run apt-get update && apt-get install -y postfix
-run postconf -e relayhost=$relay_ip
+run echo "postfix postfix/mailname string $hostname" | debconf-set-selections && \
+    echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-selections && \
+    echo "postfix postfix/relayhost string $relay_ip" | debconf-set-selections
+
+run apt-get update && apt-get install -y postfix libsasl2-modules
 run postconf -e myhostname=$hostname
 run postconf -e mydomain=$domain
-run postconf -e masquerade_domains=$domain
+run postconf -e myorigin=\$mydomain
+run postconf -e masquerade_domains=\$mydomain
 run postconf -e mydestination="\$myhostname, $hostname, localhost, localhost.localdomain, localhost"
 run postconf -e mynetworks="127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 172.0.0.0/8" 
-run postconf -e smtpd_use_tls=no
 run echo $domain > /etc/mailname
 
+# set up the credentials for SMTP authentication using username and password
+run echo "$relay_ip $smtp_login:$smtp_password" >/etc/postfix/sasl_passwd && chmod 600 /etc/postfix/sasl_passwd && postmap /etc/postfix/sasl_passwd && \
+    printf '%s\n' '# set up login for SMTP' \
+        'smtp_sasl_auth_enable=yes' \
+        'smtp_sasl_password_maps=hash:/etc/postfix/sasl_passwd' \
+        'smtp_sasl_security_options=noanonymous' \
+        'smtp_sasl_tls_security_options=noanonymous' \
+        'smtp_sasl_mechanism_filter=AUTH LOGIN' >> /etc/postfix/main.cf
+
 # This will replace local mail addresses by valid Internet addresses when mail leaves the machine via SMTP. 
-run echo "root@${hostname} iotmail@${domain}" > /etc/postfix/generic
+run echo "root@${domain} iotmail@${domain}" > /etc/postfix/generic
 run postconf -e smtp_generic_maps=hash:/etc/postfix/generic
 run postmap /etc/postfix/generic
 
@@ -40,5 +52,3 @@ run apt-get install -y mailutils
 RUN mkdir -p /etc/my_init.d
 COPY postfix.sh /etc/my_init.d/postfix.sh
 RUN chmod +x /etc/my_init.d/postfix.sh
-
-


### PR DESCRIPTION
Hello Terry,

Postfix setup was changed to use SMTP Authentication as well for using external SMTP service.  Also, The Grafana and Influxdb containers are configured to send mail via local Postfix container. 

Please review and merge it.

Thanks!.